### PR TITLE
Prevent local githooks from interfering with zkg's operations

### DIFF
--- a/testing/btest.cfg
+++ b/testing/btest.cfg
@@ -7,6 +7,7 @@ BaselineDir = baselines
 Initializer = %(testbase)s/scripts/initializer
 
 [environment]
+ORIGPATH=%(default_path)s
 PATH=%(testbase)s/scripts:%(default_path)s
 SCRIPTS=%(testbase)s/scripts
 SOURCES=%(testbase)s/sources

--- a/testing/scripts/git
+++ b/testing/scripts/git
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+# Git wrapper script for use during testing.
+
+# Use original path so we find the system's installed git, not this wrapper.
+PATH="$ORIGPATH"
+
+# Unsetting the following prevents git from reading ~/.gitconfig,
+# including potential githooks.
+HOME=
+XDG_CONFIG_HOME=
+
+git -c user.name=zkg -c user.email=zkg@zeek.org "$@"

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -888,9 +888,9 @@ class Manager(object):
 
             if source.clone.is_dirty():
                 source.clone.git.commit(
-                    '--message', 'Update aggregated metadata.')
+                    '--no-verify', '--message', 'Update aggregated metadata.')
 
-            source.clone.git.push()
+            source.clone.git.push('--no-verify')
 
         return self.SourceAggregationResults('', aggregation_issues)
 


### PR DESCRIPTION
The --no-verify option for `git commit` and `git push` disables any
locally configured hooks. Without this, a pre-commit might complain
about whitespace in a metadata aggregation commit, for example.

For testing, we provide a wrapper script that unhooks the home
directory so ~/.gitconfig can no longer interfere.